### PR TITLE
Detail url working in generated module.

### DIFF
--- a/backend/modules/module_maker/layout/templates/backend/actions/snippets/parse_meta.base.php
+++ b/backend/modules/module_maker/layout/templates/backend/actions/snippets/parse_meta.base.php
@@ -6,3 +6,4 @@
 
 		// parse additional variables
 		if($url404 != $url) $this->tpl->assign('detailURL', SITE_URL . $url);
+		$this->record['url'] = $this->meta->getURL();

--- a/backend/modules/module_maker/layout/templates/backend/layout/templates/snippets/meta.base.tpl
+++ b/backend/modules/module_maker/layout/templates/backend/layout/templates/snippets/meta.base.tpl
@@ -3,7 +3,7 @@
 
 	<div id="pageUrl">
 		<div class="oneLiner">
-			{option:detailURL}<p><span><a href="{$detailURL}">{$detailURL}/<span id="generatedUrl"></span></a></span></p>{/option:detailURL}
+			{option:detailURL}<p><span><a href="{$detailURL}/{$item.url}">{$detailURL}/<span id="generatedUrl">{$item.url}</span></a></span></p>{/option:detailURL}
 			{option:!detailURL}<p class="infoMessage">{$errNoModuleLinked}</p>{/option:!detailURL}
 		</div>
 	</div>


### PR DESCRIPTION
The detail url in the backend was not working correctly; when clicked
one would land on the 404 page.  This change fixes this, with one small
caveat:
It appears the meta.base.tpl snippet is shared between add and edit
actions, this results in {$item.url} being displayed when adding an
item, however this is shortly after replaced by the ajax action
generating the slug.  This seems like an ok trade-off for the time
being, IMHO.

Fixes #33
