### PR TITLE
Make FE model getAllCount() take language into account.

### DIFF
--- a/backend/modules/module_maker/layout/templates/frontend/engine/model.base.php
+++ b/backend/modules/module_maker/layout/templates/frontend/engine/model.base.php
@@ -84,7 +84,9 @@ class Frontend{$camel_case_name}Model
 	{
 		return (int) FrontendModel::getContainer()->get('database')->getVar(
 			'SELECT COUNT(i.id) AS count
-			 FROM {$underscored_name} AS i'
+			 FROM {$underscored_name} AS i
+			 WHERE i.language = ?',
+			array(FRONTEND_LANGUAGE)
 		);
 	}
 {$getAllByCategory}{$getAllCategories}{$getCategory}{$getCategoryCount}{$search}


### PR DESCRIPTION
Since getAll() / getAllCount() are pretty much co-existing, it seems
logical that counting should also take the language column into account.

There is actually a much more efficient way to accomplish the limit,
offset retrieving + the total number of rows by using
`SQL_CALC_FOUND_ROWS` in the base query and then, right after that
executing `SELECT FOUND_ROWS()` but this requires changing the return
type of getAll() to a tuple, as well as construction the pagination data
structure in the client code.  For this, I did not have the time (yet
;-) ).
