### PR TITLE
Patch for detail action taking wrong parameter

### DIFF
--- a/backend/modules/module_maker/layout/templates/frontend/actions/detail.base.php
+++ b/backend/modules/module_maker/layout/templates/frontend/actions/detail.base.php
@@ -38,12 +38,14 @@ class Frontend{$camel_case_name}Detail extends FrontendBaseBlock
 	private function getData()
 	{
 		$lastParameter = $this->getLastParameter();
-		if (empty($lastParameter)) {
+		if (empty($lastParameter))
+		{
 			$this->redirect(FrontendNavigation::getURL(404));
 		}
 		$this->record = Frontend{$camel_case_name}Model::get($lastParameter);
 
-		if (empty($this->record)) {
+		if (empty($this->record))
+		{
 			$this->redirect(FrontendNavigation::getURL(404));
 		}
 	}


### PR DESCRIPTION
Problem:
- When using the index and detail action from the same page we should use parameter(1)
- When using the index and detail action from different pages we should use parameter(0)

Solution:
- This patch will take the last parameter and use that for getting the data.
