### PR TITLE
Make installer template cleaner

### DIFF
--- a/src/Backend/Modules/ModuleMaker/Layout/Templates/Backend/Installer/Installer.base.php
+++ b/src/Backend/Modules/ModuleMaker/Layout/Templates/Backend/Installer/Installer.base.php
@@ -30,8 +30,8 @@ class Installer extends ModuleInstaller
         $this->setActionRights(1, '{$camel_case_name}', 'Delete');{$install_extras}
 
         // add extra's
-        $subnameID = $this->insertExtra('{$camel_case_name}', 'block', '{$camel_case_name}', null, null, 'N', 1000);
-        $this->insertExtra('{$camel_case_name}', 'block', '{$camel_case_name}Detail', 'Detail', null, 'N', 1001);
+        $subnameID = $this->insertExtra('{$camel_case_name}', 'block', '{$camel_case_name}');
+        $this->insertExtra('{$camel_case_name}', 'block', '{$camel_case_name}Detail', 'Detail');
 
 {$backend_navigation}
     }


### PR DESCRIPTION
- The sequence get generated automatically if not given, so we remove it.
- The hidden parameter should be a bool, but is false by default, so we remove it.
- The data parameter is null by default, so we remove it.
- When no action parameter is given, we remove it, as it is null by default.
